### PR TITLE
fixed POMDP deprecations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 1.0
 ReinforcementLearningBase
+POMDPs
 POMDPModels
 GR
 StatsBase

--- a/src/ReinforcementLearningEnvironmentDiscrete.jl
+++ b/src/ReinforcementLearningEnvironmentDiscrete.jl
@@ -1,5 +1,5 @@
 module ReinforcementLearningEnvironmentDiscrete
-using ReinforcementLearningBase, SparseArrays, POMDPModels, Random, LinearAlgebra
+using ReinforcementLearningBase, SparseArrays, POMDPs, POMDPModels, Random, LinearAlgebra
 import StatsBase: sample, wsample
 import GR: imshow
 import ReinforcementLearningBase: interact!, getstate, reset!, plotenv, actionspace

--- a/src/pomdps.jl
+++ b/src/pomdps.jl
@@ -19,12 +19,12 @@ MDPEnv(model) = MDPEnv(model, initialstate(model, rng), actions(model),
                        DiscreteSpace(n_actions(model), 1))
 
 actionspace(env::Union{MDPEnv, POMDPEnv}) = env.actionspace
-observation_index(env, o) = Int64(o) + 1
+observationindex(env, o) = Int64(o) + 1
 
 function interact!(env::POMDPEnv, action) 
     s, o, r = generate_sor(env.model, env.state, env.actions[action], rng)
     env.state = s
-    (observation = observation_index(env.model, o), 
+    (observation = observationindex(env.model, o), 
      reward = r, 
      isdone = isterminal(env.model, s))
 end
@@ -33,7 +33,7 @@ function reset!(env::Union{POMDPEnv, MDPEnv})
     (observation = env.state,)
 end
 function getstate(env::POMDPEnv)
-    (observation = observation_index(env.model, generate_o(env.model, env.state, rng)),
+    (observation = observationindex(env.model, generate_o(env.model, env.state, rng)),
      isdone = isterminal(env.model, env.state))
 end
 
@@ -41,12 +41,12 @@ function interact!(env::MDPEnv, action)
     s = rand(rng, transition(env.model, env.state, env.actions[action]))
     r = reward(env.model, env.state, env.actions[action])
     env.state = s
-    (observation = state_index(env.model, s), 
+    (observation = stateindex(env.model, s), 
      reward = r, 
      isdone = isterminal(env.model, s))
 end
 function getstate(env::MDPEnv)
-    (observation = state_index(env.model, env.state), 
+    (observation = stateindex(env.model, env.state), 
      isdone = isterminal(env.model, env.state))
 end
 


### PR DESCRIPTION
HI, there are a few POMDP deprecations that we didn't do a great job of rolling out. I fixed them.

Also imported POMDPs in addition to POMDPModels. The intention is that POMDPModels should not re-export everything and people should import from POMDPs. We will probably stop re-exporting in the future.